### PR TITLE
fix: 代理对象未放入单例

### DIFF
--- a/src/main/java/org/springframework/beans/factory/support/AbstractAutowireCapableBeanFactory.java
+++ b/src/main/java/org/springframework/beans/factory/support/AbstractAutowireCapableBeanFactory.java
@@ -44,6 +44,9 @@ public abstract class AbstractAutowireCapableBeanFactory extends AbstractBeanFac
 		if (bean != null) {
 			bean = applyBeanPostProcessorsAfterInitialization(bean, beanName);
 		}
+		if (beanDefinition.isSingleton()) {
+			addSingleton(beanName, bean);
+		}
 		return bean;
 	}
 


### PR DESCRIPTION
每次获取增强bean时都是一个新的对象,scope为singletone的代理对象没有放入单例集合.
