### PR TITLE
实例化单例bean时对beanDefinition的scope添加判断

### DIFF
--- a/src/main/java/org/springframework/beans/factory/support/DefaultListableBeanFactory.java
+++ b/src/main/java/org/springframework/beans/factory/support/DefaultListableBeanFactory.java
@@ -58,6 +58,10 @@ public class DefaultListableBeanFactory extends AbstractAutowireCapableBeanFacto
 
 	@Override
 	public void preInstantiateSingletons() throws BeansException {
-		beanDefinitionMap.keySet().forEach(this::getBean);
+		beanDefinitionMap.forEach((beanName, beanDefinition) -> {
+			if(beanDefinition.isSingleton()){
+				getBean(beanName);
+			}
+		});
 	}
 }


### PR DESCRIPTION
添加了对BeanDefinition的scope的判断。
```java	@Override
	public void preInstantiateSingletons() throws BeansException {
		beanDefinitionMap.forEach((beanName, beanDefinition) -> {
			if(beanDefinition.isSingleton()){
				getBean(beanName);
			}
		});
	}