### PR TITLE
fix:更正DefaultListableBeanFactory#getBeansOfType中错误

### DIFF
--- a/src/main/java/org/springframework/beans/factory/support/DefaultListableBeanFactory.java
+++ b/src/main/java/org/springframework/beans/factory/support/DefaultListableBeanFactory.java
@@ -40,13 +40,14 @@ public class DefaultListableBeanFactory extends AbstractAutowireCapableBeanFacto
 	@Override
 	public <T> Map<String, T> getBeansOfType(Class<T> type) throws BeansException {
 		Map<String, T> result = new HashMap<>();
-		beanDefinitionMap.forEach((beanName, beanDefinition) -> {
-			Class beanClass = beanDefinition.getBeanClass();
-			if (type.isAssignableFrom(beanClass)) {
+		for (Map.Entry<String, BeanDefinition> beanDefinitionWithName : beanDefinitionMap.entrySet()) {
+			String beanName = beanDefinitionWithName.getKey();
+			BeanDefinition bd = beanDefinitionWithName.getValue();
+			if(type.isAssignableFrom(bd.getBeanClass())){
 				T bean = (T) getBean(beanName);
-				result.put(beanName, bean);
+				result.put(beanName,bean);
 			}
-		});
+		}
 		return result;
 	}
 


### PR DESCRIPTION
原本在DefaultListableBeanFactory#getBeansOfType中使用的forEach中无法处理getBean抛出的BeansException。