### PR TITLE
初始化方法增加判断是否与InitializingBean方法同名

### DIFF
--- a/src/main/java/org/springframework/beans/factory/support/AbstractAutowireCapableBeanFactory.java
+++ b/src/main/java/org/springframework/beans/factory/support/AbstractAutowireCapableBeanFactory.java
@@ -153,7 +153,7 @@ public abstract class AbstractAutowireCapableBeanFactory extends AbstractBeanFac
 			((InitializingBean) bean).afterPropertiesSet();
 		}
 		String initMethodName = beanDefinition.getInitMethodName();
-		if (StrUtil.isNotEmpty(initMethodName)) {
+		if (StrUtil.isNotEmpty(initMethodName) && !(bean instanceof InitializingBean && "afterPropertiesSet".equals(initMethodName))) {
 			Method initMethod = ClassUtil.getPublicMethod(beanDefinition.getBeanClass(), initMethodName);
 			if (initMethod == null) {
 				throw new BeansException("Could not find an init method named '" + initMethodName + "' on bean with name '" + beanName + "'");


### PR DESCRIPTION
避免继承自InitializingBean，且自定义方法与InitializingBean方法同名，初始化方法执行两次的情况
#63 