### PR TITLE
修复当类的scope为prototype时循环依赖问题依旧存在的bug

### DIFF
--- a/src/main/java/org/springframework/beans/factory/support/AbstractAutowireCapableBeanFactory.java
+++ b/src/main/java/org/springframework/beans/factory/support/AbstractAutowireCapableBeanFactory.java
@@ -70,7 +70,7 @@ public abstract class AbstractAutowireCapableBeanFactory extends AbstractBeanFac
 			bean = createBeanInstance(beanDefinition);
 
 			//为解决循环依赖问题，将实例化后的bean放进缓存中提前暴露
-			if (beanDefinition.isSingleton()) {
+
 				Object finalBean = bean;
 				addSingletonFactory(beanName, new ObjectFactory<Object>() {
 					@Override
@@ -78,7 +78,7 @@ public abstract class AbstractAutowireCapableBeanFactory extends AbstractBeanFac
 						return getEarlyBeanReference(beanName, beanDefinition, finalBean);
 					}
 				});
-			}
+
 
 			//实例化bean之后执行
 			boolean continueWithPropertyPopulation = applyBeanPostProcessorsAfterInstantiation(beanName, bean);
@@ -104,6 +104,8 @@ public abstract class AbstractAutowireCapableBeanFactory extends AbstractBeanFac
 			exposedObject = getSingleton(beanName);
 			addSingleton(beanName, exposedObject);
 		}
+		//删除除第一级缓存外的缓存
+		removeOtherCache(beanName);
 		return exposedObject;
 	}
 

--- a/src/main/java/org/springframework/beans/factory/support/DefaultSingletonBeanRegistry.java
+++ b/src/main/java/org/springframework/beans/factory/support/DefaultSingletonBeanRegistry.java
@@ -51,6 +51,11 @@ public class DefaultSingletonBeanRegistry implements SingletonBeanRegistry {
 		singletonFactories.remove(beanName);
 	}
 
+	public void removeOtherCache(String beanName) {
+		earlySingletonObjects.remove(beanName);
+		singletonFactories.remove(beanName);
+	}
+
 	protected void addSingletonFactory(String beanName, ObjectFactory<?> singletonFactory) {
 		singletonFactories.put(beanName, singletonFactory);
 	}

--- a/src/test/java/org/springframework/test/ioc/CircularReferenceWithoutProxyBeanTest.java
+++ b/src/test/java/org/springframework/test/ioc/CircularReferenceWithoutProxyBeanTest.java
@@ -2,8 +2,7 @@ package org.springframework.test.ioc;
 
 import org.junit.Test;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
-import org.springframework.test.bean.A;
-import org.springframework.test.bean.B;
+import org.springframework.test.bean.*;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
@@ -18,6 +17,10 @@ public class CircularReferenceWithoutProxyBeanTest {
 		ClassPathXmlApplicationContext applicationContext = new ClassPathXmlApplicationContext("classpath:circular-reference-without-proxy-bean.xml");
 		A a = applicationContext.getBean("a", A.class);
 		B b = applicationContext.getBean("b", B.class);
-		assertThat(a.getB() == b).isTrue();
+		A a1 = applicationContext.getBean("a", A.class);
+		A a2 = applicationContext.getBean("a", A.class);
+		assertThat(a.getB() == b).isFalse();
+		assertThat(a1.getB() == a2.getB()).isFalse();
+		assertThat(a1 == a2).isFalse();
 	}
 }

--- a/src/test/resources/circular-reference-without-proxy-bean.xml
+++ b/src/test/resources/circular-reference-without-proxy-bean.xml
@@ -7,11 +7,11 @@
 		 http://www.springframework.org/schema/context
 		 http://www.springframework.org/schema/context/spring-context-4.0.xsd">
 
-    <bean id="a" class="org.springframework.test.bean.A">
+    <bean id="a" class="org.springframework.test.bean.A" scope="prototype">
         <property name="b" ref="b"/>
     </bean>
 
-    <bean id="b" class="org.springframework.test.bean.B">
+    <bean id="b" class="org.springframework.test.bean.B" scope="prototype">
         <property name="a" ref="a"/>
     </bean>
 


### PR DESCRIPTION
![image](https://github.com/DerekYRC/mini-spring/assets/150537646/85136751-e9c4-448e-b65e-72281980c46c)
设置scope为prototype
![image](https://github.com/DerekYRC/mini-spring/assets/150537646/bf451c15-1749-465e-8749-523387e91473)
循环依赖导致栈溢出


![image](https://github.com/DerekYRC/mini-spring/assets/150537646/3343f7de-ecd1-4283-a8cb-75d9aa3ebb37)
原因在于只有当前bean的scope为singleton才会提前暴露，这就无法解决scope为prototype时的循环依赖。

![image](https://github.com/DerekYRC/mini-spring/assets/150537646/1c49c087-d9c5-4f59-a553-59aaa6e407c3)
所以这里直接让任何bean都可以提前暴露
![image](https://github.com/DerekYRC/mini-spring/assets/150537646/108a7bc6-3a21-4547-99cb-1d0f3ae01e58)
然后在bean创建好了后，删除除了第一级缓存外的所有缓存