### PR TITLE
更新common-advice分支

### DIFF
--- a/src/test/java/org/springframework/test/aop/DynamicProxyTest.java
+++ b/src/test/java/org/springframework/test/aop/DynamicProxyTest.java
@@ -104,9 +104,9 @@ public class DynamicProxyTest {
     public void testThrowsAdvice() throws Exception {
         WorldService worldService = new WorldServiceWithExceptionImpl();
         //设置ThrowsAdvice
-        WorldServiceAfterReturningAdvice afterReturningAdvice = new WorldServiceAfterReturningAdvice();
+        WorldServiceThrowsAdvice throwsAdvice = new WorldServiceThrowsAdvice();
         GenericInterceptor methodInterceptor = new GenericInterceptor();
-        methodInterceptor.setAfterReturningAdvice(afterReturningAdvice);
+        methodInterceptor.setThrowsAdvice( throwsAdvice);
         advisedSupport.setMethodInterceptor(methodInterceptor);
         advisedSupport.setTargetSource(new TargetSource(worldService));
 


### PR DESCRIPTION
common-advice分支中，testThrowsAdvice和testAfterReturningAdvice的内容重复，并没有达到测试ThrowsAdvice的作用，已修改