### PR TITLE
bean名称标准处理

### DIFF
--- a/src/main/java/org/springframework/context/annotation/ClassPathBeanDefinitionScanner.java
+++ b/src/main/java/org/springframework/context/annotation/ClassPathBeanDefinitionScanner.java
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.stereotype.Component;
 
+import java.beans.Introspector;
 import java.util.Set;
 
 /**
@@ -64,7 +65,7 @@ public class ClassPathBeanDefinitionScanner extends ClassPathScanningCandidateCo
 		Component component = beanClass.getAnnotation(Component.class);
 		String value = component.value();
 		if (StrUtil.isEmpty(value)) {
-			value = StrUtil.lowerFirst(beanClass.getSimpleName());
+			value = Introspector.decapitalize(beanClass.getSimpleName());
 		}
 		return value;
 	}


### PR DESCRIPTION
Spring源码中Bean名称并不是简单类名的首字母小写，形象一点说Thus "FooBah" becomes "fooBah" and "X" becomes "x", but "URL" stays as "URL".