### PR TITLE
feat: 完善 CommonAdvice 支持 AroundAdvice，环绕通知

### DIFF
--- a/src/main/java/org/springframework/aop/AroundAdvice.java
+++ b/src/main/java/org/springframework/aop/AroundAdvice.java
@@ -1,0 +1,14 @@
+package org.springframework.aop;
+
+import org.aopalliance.intercept.MethodInvocation;
+
+/**
+ * 环绕通知
+ *
+ * @author NingMao
+ * @since 2025-07-12
+ */
+public interface AroundAdvice {
+
+    Object around(MethodInvocation invocation) throws Throwable;
+}

--- a/src/main/java/org/springframework/aop/GenericInterceptor.java
+++ b/src/main/java/org/springframework/aop/GenericInterceptor.java
@@ -12,10 +12,17 @@ public class GenericInterceptor implements MethodInterceptor {
     private AfterAdvice afterAdvice;
     private AfterReturningAdvice afterReturningAdvice;
     private ThrowsAdvice throwsAdvice;
+    private AroundAdvice aroundAdvice;
 
 
     @Override
     public Object invoke(MethodInvocation invocation) throws Throwable {
+        // 如果配置了环绕通知，则优先执行环绕通知
+        if (aroundAdvice != null) {
+            // 环绕通知会通过 invocation.proceed() 来触发后续的通知链或目标方法执行
+            return aroundAdvice.around(invocation);
+        }
+
         Object result = null;
         try {
             // 前置通知
@@ -56,4 +63,6 @@ public class GenericInterceptor implements MethodInterceptor {
     public void setAfterAdvice(AfterAdvice afterAdvice) {
         this.afterAdvice = afterAdvice;
     }
+
+    public void setAroundAdvice(AroundAdvice aroundAdvice) {this.aroundAdvice = aroundAdvice;}
 }

--- a/src/test/java/org/springframework/test/aop/DynamicProxyTest.java
+++ b/src/test/java/org/springframework/test/aop/DynamicProxyTest.java
@@ -9,11 +9,8 @@ import org.springframework.aop.aspectj.AspectJExpressionPointcut;
 import org.springframework.aop.framework.CglibAopProxy;
 import org.springframework.aop.framework.JdkDynamicAopProxy;
 import org.springframework.aop.framework.ProxyFactory;
-import org.springframework.test.common.WorldServiceAfterAdvice;
-import org.springframework.test.common.WorldServiceAfterReturningAdvice;
-import org.springframework.test.common.WorldServiceBeforeAdvice;
+import org.springframework.test.common.*;
 import org.springframework.aop.GenericInterceptor;
-import org.springframework.test.common.WorldServiceThrowsAdvice;
 import org.springframework.test.service.WorldService;
 import org.springframework.test.service.WorldServiceImpl;
 import org.springframework.test.service.WorldServiceWithExceptionImpl;
@@ -139,6 +136,16 @@ public class DynamicProxyTest {
         advisedSupport.setMethodInterceptor(methodInterceptor);
         advisedSupport.setTargetSource(new TargetSource(worldService));
 
+        WorldService proxy = (WorldService) new ProxyFactory(advisedSupport).getProxy();
+        proxy.explode();
+    }
+
+    @Test
+    public void testAroundAdvice() throws Exception {
+        WorldServiceAroundAdvice aroundAdvice = new WorldServiceAroundAdvice();
+        GenericInterceptor methodInterceptor = new GenericInterceptor();
+        methodInterceptor.setAroundAdvice(aroundAdvice);
+        advisedSupport.setMethodInterceptor(methodInterceptor);
         WorldService proxy = (WorldService) new ProxyFactory(advisedSupport).getProxy();
         proxy.explode();
     }

--- a/src/test/java/org/springframework/test/common/WorldServiceAroundAdvice.java
+++ b/src/test/java/org/springframework/test/common/WorldServiceAroundAdvice.java
@@ -1,0 +1,27 @@
+package org.springframework.test.common;
+
+import org.aopalliance.intercept.MethodInvocation;
+import org.springframework.aop.AroundAdvice;
+
+/**
+ * @author NingMao
+ * @since 2025-07-12
+ */
+public class WorldServiceAroundAdvice implements AroundAdvice {
+    @Override
+    public Object around(MethodInvocation invocation) throws Throwable {
+        System.out.println("--- 环绕通知：方法执行前操作 ---");
+        Object result;
+        try {
+            // 调用链的下一个方法（可能是目标方法，也可能是其他普通通知）
+            result = invocation.proceed();
+            System.out.println("--- 环绕通知：方法成功返回后操作 ---");
+        } catch (Throwable e) {
+            System.out.println("--- 环绕通知：方法抛出异常后操作： " + e.getMessage() + " ---");
+            throw e; // 确保异常继续传播
+        } finally {
+            System.out.println("--- 环绕通知：方法最终结束操作 ---");
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
### 改动内容
增加了Around Advice环绕通知，代码结构清晰工整

### 背景
当前 `common-advice` 分支未实现SpringBoot中最常用的环绕通知，本 PR 进行了补全。

### 合并目标
请求合并到 `common-advice` 分支。
