### PR TITLE
fix(mini-spring):修复循环依赖场景下代理对象重复创建的问题

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1777,6 +1777,7 @@ public class AfterReturningAdviceInterceptor implements MethodInterceptor, After
 #### [测试](#测试)
 
 ！！！！！！！注意，使用过高版本的java可以因为java版本和cjlib冲突导致报错。建议使用java8进行测试
+另外一种方式：可以在jvm启动的时候添加参数:--add-opens java.base/java.lang=ALL-UNNAMED
 
 ```java
 public class WorldServiceImpl implements WorldService {

--- a/src/main/java/org/springframework/beans/factory/support/AbstractAutowireCapableBeanFactory.java
+++ b/src/main/java/org/springframework/beans/factory/support/AbstractAutowireCapableBeanFactory.java
@@ -101,10 +101,10 @@ public abstract class AbstractAutowireCapableBeanFactory extends AbstractBeanFac
 		Object exposedObject = bean;
 		if (beanDefinition.isSingleton()) {
 			//如果有代理对象，此处获取代理对象
-			Object fromEarlySingletonObjects = getSingleton(beanName, false);
-			if(fromEarlySingletonObjects != null){
-				//如果二级缓存中查询出来bean不为null的话，说明存在循环依赖，那我们最后的bean就要和二级缓存中的bean一致；如果二级缓存中bean为null的话，不存在循环依赖，最后的bean为初始化的bean。
-				exposedObject = fromEarlySingletonObjects;
+			Object earlySingletonReference = getSingleton(beanName, false);
+			if(earlySingletonReference != null){
+				//一级,二级缓存中的bean保持一致
+				exposedObject = earlySingletonReference;
 			}
 			addSingleton(beanName, exposedObject);
 		}

--- a/src/main/java/org/springframework/beans/factory/support/AbstractAutowireCapableBeanFactory.java
+++ b/src/main/java/org/springframework/beans/factory/support/AbstractAutowireCapableBeanFactory.java
@@ -101,7 +101,11 @@ public abstract class AbstractAutowireCapableBeanFactory extends AbstractBeanFac
 		Object exposedObject = bean;
 		if (beanDefinition.isSingleton()) {
 			//如果有代理对象，此处获取代理对象
-			exposedObject = getSingleton(beanName);
+			Object fromEarlySingletonObjects = getSingleton(beanName, false);
+			if(fromEarlySingletonObjects != null){
+				//如果二级缓存中查询出来bean不为null的话，说明存在循环依赖，那我们最后的bean就要和二级缓存中的bean一致；如果二级缓存中bean为null的话，不存在循环依赖，最后的bean为初始化的bean。
+				exposedObject = fromEarlySingletonObjects;
+			}
 			addSingleton(beanName, exposedObject);
 		}
 		return exposedObject;

--- a/src/main/java/org/springframework/beans/factory/support/DefaultSingletonBeanRegistry.java
+++ b/src/main/java/org/springframework/beans/factory/support/DefaultSingletonBeanRegistry.java
@@ -34,10 +34,15 @@ public class DefaultSingletonBeanRegistry implements SingletonBeanRegistry {
 
 	@Override
 	public Object getSingleton(String beanName) {
+		return getSingleton(beanName,true);
+	}
+
+	public Object getSingleton(String beanName,boolean allowEarlyReference) {
 		Object singletonObject = singletonObjects.get(beanName);
 		if (singletonObject == null) {
 			singletonObject = earlySingletonObjects.get(beanName);
-			if (singletonObject == null) {
+			//不是所有的getSingleton()都要去三级缓存里面查！
+			if (singletonObject == null && allowEarlyReference) {
 				ObjectFactory<?> singletonFactory = singletonFactories.get(beanName);
 				if (singletonFactory != null) {
 					singletonObject = singletonFactory.getObject();

--- a/src/test/java/org/springframework/test/bean/C.java
+++ b/src/test/java/org/springframework/test/bean/C.java
@@ -1,0 +1,7 @@
+package org.springframework.test.bean;
+
+public class C {
+    public void sayHello(){
+        System.out.println("I'm C ");
+    }
+}

--- a/src/test/java/org/springframework/test/ioc/CircularReferenceWIthProxyBeanTest2.java
+++ b/src/test/java/org/springframework/test/ioc/CircularReferenceWIthProxyBeanTest2.java
@@ -1,35 +1,78 @@
 package org.springframework.test.ioc;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.test.bean.A;
 import org.springframework.test.bean.B;
 import org.springframework.test.bean.C;
+import org.springframework.test.service.HelloService;
 
 public class CircularReferenceWIthProxyBeanTest2 {
+
     /**
-     * 无循环依赖的代理对象，二级缓存为空，且allowEarlyReference为false，不查三级缓存，将初始化后的bean添加到一级缓存中！没毛病
+     * 测试1：无循环依赖的普通对象 (spring.xml配置文件中的helloService对象)
+     *
+     * BeanPostprocessor后置处理器返回原始bean，收尾阶段，二级缓存中无值，说明无循环依赖，将初始化的bean添加到一级缓存
      */
     @Test
-    public void test1(){
+    public void test1() {
+        ApplicationContext context = new ClassPathXmlApplicationContext("classpath:spring.xml");
+        HelloService helloService = context.getBean("helloService", HelloService.class);
+        helloService.sayHello();
+    }
+
+
+    /**
+     * 测试2: 无循环依赖的代理对象 (circular-reference-with-proxy-bean-2.xml中的c对象)
+     *
+     * BeanPostprocessor后置处理器返回代理bean，收尾阶段，二级缓存中无值，说明无循环依赖，将代理bean添加到一级缓存
+     */
+    @Test
+    public void test2() {
         ApplicationContext context = new ClassPathXmlApplicationContext("classpath:circular-reference-with-proxy-bean-2.xml");
         C c = (C) context.getBean("c");
         c.sayHello();
     }
 
+
     /**
-     * 循环依赖的代理对象，二级缓存不为空，且allowEarlyReference为false，不查三级缓存，将二级缓存中的bean添加到一级缓存，保证其他依赖该类的bean的属性 和 该bean一致！
+     * 测试3：存在循环依赖的普通对象 (circular-reference-without-proxy-bean.xml中的a,b对象)
+     *
+     * BeanPostprocessor后置处理器返回普通bean,收尾阶段，二级缓存中有值，说明有循环依赖，为了确保a.getB() == b ，将二级缓存中bean添加到一级缓存
+     *
      */
     @Test
-    public void test2(){
-        ApplicationContext context =new ClassPathXmlApplicationContext("classpath:circular-reference-with-proxy-bean.xml");
+    public void test3() {
+        ApplicationContext context = new ClassPathXmlApplicationContext("classpath:circular-reference-without-proxy-bean.xml");
+        //A为普通对象
+        A a = (A) context.getBean("a");
+        //B为普通对象
+        B b = (B) context.getBean("b");
+
+        Assert.assertTrue(a.getB() == b);
+        Assert.assertTrue(b.getA() == a);
+    }
+
+
+    /**
+     * 测试4：存在循环依赖的代理对象(circular-reference-with-proxy-bean.xml 中的a对象)
+     *
+     * BeanPostprocessor后置处理器跳过执行，收尾阶段，二级缓存中有代理对象，将二级缓存添加到一级缓存中
+     */
+    @Test
+    public void test4() {
+        ApplicationContext context = new ClassPathXmlApplicationContext("classpath:circular-reference-with-proxy-bean.xml");
         //A为代理对象
         A a = (A) context.getBean("a");
         //B为普通对象
         B b = (B) context.getBean("b");
 
         a.func();
+
+        //对象a的二级缓存和一级缓存内容一致，因此b.getA() == a 为 true
+        Assert.assertTrue(b.getA() == a);
     }
 
 }

--- a/src/test/java/org/springframework/test/ioc/CircularReferenceWIthProxyBeanTest2.java
+++ b/src/test/java/org/springframework/test/ioc/CircularReferenceWIthProxyBeanTest2.java
@@ -1,0 +1,35 @@
+package org.springframework.test.ioc;
+
+import org.junit.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.test.bean.A;
+import org.springframework.test.bean.B;
+import org.springframework.test.bean.C;
+
+public class CircularReferenceWIthProxyBeanTest2 {
+    /**
+     * 无循环依赖的代理对象，二级缓存为空，且allowEarlyReference为false，不查三级缓存，将初始化后的bean添加到一级缓存中！没毛病
+     */
+    @Test
+    public void test1(){
+        ApplicationContext context = new ClassPathXmlApplicationContext("classpath:circular-reference-with-proxy-bean-2.xml");
+        C c = (C) context.getBean("c");
+        c.sayHello();
+    }
+
+    /**
+     * 循环依赖的代理对象，二级缓存不为空，且allowEarlyReference为false，不查三级缓存，将二级缓存中的bean添加到一级缓存，保证其他依赖该类的bean的属性 和 该bean一致！
+     */
+    @Test
+    public void test2(){
+        ApplicationContext context =new ClassPathXmlApplicationContext("classpath:circular-reference-with-proxy-bean.xml");
+        //A为代理对象
+        A a = (A) context.getBean("a");
+        //B为普通对象
+        B b = (B) context.getBean("b");
+
+        a.func();
+    }
+
+}

--- a/src/test/resources/circular-reference-with-proxy-bean-2.xml
+++ b/src/test/resources/circular-reference-with-proxy-bean-2.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+       http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <!-- c被代理 -->
+    <bean id="c" class="org.springframework.test.bean.C"/>
+
+    <!-- BeanPostProcess实现类 -->
+    <bean class="org.springframework.aop.framework.autoproxy.DefaultAdvisorAutoProxyCreator"/>
+
+    <!--    pontcutAdvisor类-->
+    <bean id="pointcutAdvisor" class="org.springframework.aop.aspectj.AspectJExpressionPointcutAdvisor">
+        <property name="expression" value="execution(* org.springframework.test.bean.C.*(..))"/>
+        <property name="advice" ref="methodInterceptor"/>
+    </bean>
+
+    <!--    增强类-->
+    <bean id="methodInterceptor" class="org.springframework.aop.framework.adapter.MethodBeforeAdviceInterceptor">
+        <property name="advice" ref="beforeAdvice"/>
+    </bean>
+
+    <!--    前置增强-->
+    <bean id="beforeAdvice" class="org.springframework.test.common.ABeforeAdvice"/>
+</beans>


### PR DESCRIPTION
1.支持通过allowEarlyReference控制是否访问三级缓存；
2.解决无循环依赖代理对象重复问题