### PR TITLE
[ISSUE #95] Fix proxy destroy method lookup

### DIFF
--- a/src/main/java/org/springframework/beans/factory/support/DisposableBeanAdapter.java
+++ b/src/main/java/org/springframework/beans/factory/support/DisposableBeanAdapter.java
@@ -20,10 +20,14 @@ public class DisposableBeanAdapter implements DisposableBean {
 
 	private final String destroyMethodName;
 
+	private final Class<?> beanClass;
+
 	public DisposableBeanAdapter(Object bean, String beanName, BeanDefinition beanDefinition) {
 		this.bean = bean;
 		this.beanName = beanName;
 		this.destroyMethodName = beanDefinition.getDestroyMethodName();
+		// 保存原始类（而不是代理类），用于查找方法
+		this.beanClass = beanDefinition.getBeanClass();
 	}
 
 	@Override
@@ -35,7 +39,13 @@ public class DisposableBeanAdapter implements DisposableBean {
 		//避免同时继承自DisposableBean，且自定义方法与DisposableBean方法同名，销毁方法执行两次的情况
 		if (StrUtil.isNotEmpty(destroyMethodName) && !(bean instanceof DisposableBean && "destroy".equals(this.destroyMethodName))) {
 			//执行自定义方法
-			Method destroyMethod = ClassUtil.getPublicMethod(bean.getClass(), destroyMethodName);
+			// 优先从原始类（而非代理类）查找方法
+			Class<?> targetClass = beanClass != null ? beanClass : bean.getClass();
+			Method destroyMethod = ClassUtil.getPublicMethod(targetClass, destroyMethodName);
+			if (destroyMethod == null && targetClass != bean.getClass()) {
+				// 如果原始类找不到，尝试从代理类查找
+				destroyMethod = ClassUtil.getPublicMethod(bean.getClass(), destroyMethodName);
+			}
 			if (destroyMethod == null) {
 				throw new BeansException("Couldn't find a destroy method named '" + destroyMethodName + "' on bean with name '" + beanName + "'");
 			}

--- a/src/main/java/org/springframework/beans/factory/xml/XmlBeanDefinitionReader.java
+++ b/src/main/java/org/springframework/beans/factory/xml/XmlBeanDefinitionReader.java
@@ -17,6 +17,7 @@ import org.springframework.context.annotation.ClassPathBeanDefinitionScanner;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 
+import java.beans.Introspector;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
@@ -106,8 +107,9 @@ public class XmlBeanDefinitionReader extends AbstractBeanDefinitionReader {
 			//id优先于name
 			beanName = StrUtil.isNotEmpty(beanId) ? beanId : beanName;
 			if (StrUtil.isEmpty(beanName)) {
-				//如果id和name都为空，将类名的第一个字母转为小写后作为bean的名称
-				beanName = StrUtil.lowerFirst(clazz.getSimpleName());
+				// 使用 Introspector.decapitalize 遵循 Spring 源码规则:
+				// "URL" -> "URL", "X" -> "x", "FooBah" -> "fooBah"
+				beanName = Introspector.decapitalize(clazz.getSimpleName());
 			}
 
 			BeanDefinition beanDefinition = new BeanDefinition(clazz);


### PR DESCRIPTION
When a bean uses JDK dynamic proxy with custom init-destroy methods, the proxy class cannot find methods in the original class. This fix stores the original bean class and searches for destroy method in both original and proxy classes.